### PR TITLE
Fix comment typo in coord_diff.m

### DIFF
--- a/coord_diff.m
+++ b/coord_diff.m
@@ -2,7 +2,7 @@
 
 % computes covariance matrix of coordinate differences of two points
 % cm_file  ...  covariance matrix
-% p1, p12  ...  indexes of point 1 and point 2
+% p1, p2  ...  indexes of point 1 and point 2
 % dim      ...  network points dimension (1,2,3)
 
 


### PR DESCRIPTION
## Summary
- fix typo in the comment describing point arguments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68442f281558832c83b5f96604706d4e