### PR TITLE
Add gamaxml2txt parser test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_gamaxml2txt.py
+++ b/tests/test_gamaxml2txt.py
@@ -1,0 +1,12 @@
+import io
+from contextlib import redirect_stdout
+from gamaxml2txt import gamaXMLParser
+
+
+def test_parse_adj_xml_first_line():
+    parser = gamaXMLParser()
+    out = io.StringIO()
+    with open('examples/adj.xml', 'rb') as f, redirect_stdout(out):
+        parser.parse_file(f)
+    first_line = out.getvalue().splitlines()[0]
+    assert first_line == "9701 486568.551000 5377832.049000 290.700000 #xyz_fix"


### PR DESCRIPTION
## Summary
- add parser output test for gamaxml2txt
- ensure repo root is in `sys.path` during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442f2a7d80832c9838f81f3684a181