### PR TITLE
Fix typo in examples Makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,6 @@
 .PHONY: prep adj coord
 
-all: prep ajd coord
+all: prep adj coord
 
 prep:
 	../mapa2gkf.awk -v dir=10 dist="1 1.5" meas.asc > meas.gkf


### PR DESCRIPTION
## Summary
- fix typographical error in `examples/Makefile` target for `all`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844300a1c14832cb3e58b1f214ee2a1